### PR TITLE
Plus sign is added as allowed for header params

### DIFF
--- a/src/libmime.js
+++ b/src/libmime.js
@@ -469,7 +469,7 @@ var libmime = module.exports = {
         maxLength = maxLength || 50;
 
         // process ascii only text
-        if (/^[\w.\- ]*$/.test(data)) {
+        if (/^[\w.\-+ ]*$/.test(data)) {
 
             // check if conversion is even needed
             if (encodedStr.length <= maxLength) {


### PR DESCRIPTION
Useful for filenames contains "+" sign when using with Nodemailer